### PR TITLE
Added opus_get_version_string()

### DIFF
--- a/pyogg/opus.py
+++ b/pyogg/opus.py
@@ -560,6 +560,12 @@ if PYOGG_OPUS_AVAIL and PYOGG_OPUS_FILE_AVAIL:
     def opus_multistream_packet_unpad(data, len, nb_streams):
         return libopus.opus_multistream_packet_unpad(data, len, nb_streams)
       
+    libopus.opus_get_version_string.restype = c_char_p
+    libopus.opus_get_version_string.argtypes = None
+
+    def opus_get_version_string():
+        return libopus.opus_get_version_string()
+
     # /opus
 
     # opus_multistream


### PR DESCRIPTION
Hi Zuzu-Typ,

Thanks enormously for your work on PyOgg, it's greatly appreciated at this end.

Here is a very small contribution that adds opus_get_version_string().  I see that you had included similar functionality for libopusenc and libvorbis, so I thought this might be good as my first contribution to your work.

I'm also interested in contributing to documentation if you're open to that.

Thanks again,

Matthew